### PR TITLE
Fix ScaleIn server count, add hcloud_networks, change retry default, add conf in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
 # nomad-hcloud-autoscaler
+
+Example configuration
+
+`config.hcl`
+```
+template {
+    data = <<-EOF
+    nomad {
+        address = "http://{{env "attr.unique.network.ip-address" }}:4646"
+    }
+
+    telemetry {
+        prometheus_metrics = true
+        disable_hostname   = true
+    }
+
+    apm "prometheus" {
+        driver = "prometheus"
+        config = {
+            address = "http://{{ range service "prometheus" }}{{ .Address }}:{{ .Port }}{{ end }}"
+        }
+    }
+
+    strategy "target-value" {
+        driver = "target-value"
+        
+    }
+
+    target "hcloud-server" {
+        driver = "hcloud-server"
+        config = {
+            hcloud_token = "YOUR_HCLOUD_TOKEN"
+        }
+    }
+    
+    EOF
+
+    destination = "${NOMAD_TASK_DIR}/config.hcl"
+    change_mode = "signal"
+    change_signal = "SIGHUP"
+}
+```
+
+`policy`
+
+```
+template {
+    data = <<-EOF
+    scaling  "cluster_class-batch"{
+        enabled = true
+        min     = 1
+        max     = 2
+
+        policy {
+        cooldown            = "5m"
+        evaluation_interval = "5m"
+
+        check "test-scale" {
+            source = "prometheus"
+            query  = "YOUR_DESIRED_METRIC"
+
+            strategy "target-value" {
+            target = 2
+            }
+        }
+
+        target "hcloud-server" {
+            // datacenter = "XXX"
+            node_class = "XXX"
+            dry-run             = "false"
+            // node_selector_strategy = "newest_create_index"
+            hcloud_location = "XXX"
+            hcloud_image = "XXX"
+            hcloud_user_data = ""
+            hcloud_ssh_keys = "XXX"
+            hcloud_server_type = "cx11"
+            hcloud_name_prefix = "XXX"
+            hcloud_labels = "XXX_node=true"
+            hcloud_networks = "XXX"
+        }
+        }
+    }
+    EOF
+    destination = "${NOMAD_TASK_DIR}/policies/hcloud.hcl"
+    change_mode = "signal"
+    change_signal = "SIGHUP"
+}
+```

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -29,6 +29,7 @@ const (
 	configKeyLabels     = "hcloud_labels"
 	configKeyServerType = "hcloud_server_type"
 	configKeyNamePrefix = "hcloud_name_prefix"
+	configKeyNetworks   = "hcloud_networks"
 )
 
 var (


### PR DESCRIPTION
Hi,  
thank you for writing this.  
I'm using it and I made the following changes:

- change retry default to 60s
- change ScaleIn to use "count" to determine the number of servers to be deleted
- add `hcloud_networks` param to be able to connect the servers to HCloud Networks
- add a (very) basic README containing an example of the configuration and scaling policy
