### PR TITLE
allow reading userdata from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ check "hashistack-allocated-cpu" {
 
 - `hcloud_group_id` `(string: required)` - Server group name used for filtering targeted HCloud hosts. `group-id` label is attached to a server during creation.
 
-- `hcloud_user_data` `(string: required)` - [Cloud-Init][cloud_init] user data to use during Server creation. This field is limited to 32KiB.
+- `hcloud_user_data` `(string: required)` - [Cloud-Init][cloud_init] user data to use during Server creation. This field is limited to 32KiB (must not be used together with `hcloud_user_data_file`).
 
-- `hcloud_b64_user_data_encoded` `(string: "false")` - Identifies if `hcloud_user_data` is base64 encoded or not.
+- `hcloud_b64_user_data_encoded` `(string: "false")` - Identifies if `hcloud_user_data` (or the content of the file specified in `hcloud_user_data_file`) is base64 encoded or not.
+
+- `hcloud_user_data_file` `(string: required)` - [Cloud-Init][cloud_init] user data file to use during Server creation (must not be used together with `hcloud_user_data`).
 
 - `hcloud_ssh_keys` `(string: required)` - Comma-separated IDs or names of SSH keys which should be injected into the server at creation time.
 
@@ -118,7 +120,7 @@ check "hashistack-allocated-cpu" {
 [node_selector_strategy]: /tools/autoscaling/internals/node-selector-strategy
 
 ## Demo
-Run `terraform apply` in [demo](demo/setup) folder to create: 
+Run `terraform apply` in [demo](demo/setup) folder to create:
  - nomad server which runs services for:
     - nomad-autoscaler
     - prometheus

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -113,7 +113,8 @@ type hcloudTargetConfig struct {
 	PlacementGroup      *hcloud.PlacementGroup         `mapstructure:"hcloud_placement_group"`
 	Firewalls           []*hcloud.ServerCreateFirewall `mapstructure:"hcloud_firewalls"`
 	Image               *hcloud.Image                  `mapstructure:"hcloud_image" default:"{\"Name\": \"ubuntu-20.04\"}" validate:"required"`
-	UserData            string                         `mapstructure:"hcloud_user_data" validate:"required"`
+	UserData            string                         `mapstructure:"hcloud_user_data" validate:"required_without=UserDataFile"`
+	UserDataFile        string                         `mapstructure:"hcloud_user_data_file" validate:"required_without=UserData"`
 	SSHKeys             []*hcloud.SSHKey               `mapstructure:"hcloud_ssh_keys" validate:"required"`
 	Labels              map[string]string              `mapstructure:"hcloud_labels"`
 	ServerType          *hcloud.ServerType             `mapstructure:"hcloud_server_type" default:"{\"Name\":\"cx11\"}" validate:"required"`


### PR DESCRIPTION
I'm using the user data file to provision secrets, therefore I need to pull it in dynamically from a file to not have the secrets visible in my configuration management. I've added the option "hcloud_user_data_file" to support that.